### PR TITLE
[BLAS] Fix complex header inclusion and multi_ptr cast

### DIFF
--- a/onemath/sycl/blas/include/blas_meta.h
+++ b/onemath/sycl/blas/include/blas_meta.h
@@ -30,10 +30,10 @@
 #ifdef BLAS_ENABLE_COMPLEX
 #define SYCL_EXT_ONEAPI_COMPLEX
 #include <complex>
-#if __has_include(<ext/oneapi/experimental/complex/complex.hpp>)
-#include <ext/oneapi/experimental/complex/complex.hpp>
+#if __has_include(<sycl/ext/oneapi/experimental/complex/complex.hpp>)
+#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
 #else
-#include <ext/oneapi/experimental/sycl_complex.hpp>
+#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
 #endif
 #endif
 

--- a/onemath/sycl/blas/src/operations/blas3/gemm_load_store_complex.hpp
+++ b/onemath/sycl/blas/src/operations/blas3/gemm_load_store_complex.hpp
@@ -116,10 +116,24 @@ class vec_complex {
     m_Data = *(Ptr + Offset * NumElements);
   }
 
+  // Load
+  template <address_t Space, decorated_t DecorateAddress>
+  void load(size_t Offset,
+            const DataT* Ptr) {
+    m_Data = *(Ptr + Offset * NumElements);
+  }
+
   // Store
   template <address_t Space, decorated_t DecorateAddress>
   void store(size_t Offset,
              sycl::multi_ptr<DataT, Space, DecorateAddress> Ptr) const {
+    *(Ptr + Offset * NumElements) = m_Data;
+  }
+
+  // Store
+  template <address_t Space, decorated_t DecorateAddress>
+  void store(size_t Offset,
+             DataT* Ptr) const {
     *(Ptr + Offset * NumElements) = m_Data;
   }
 };

--- a/onemath/sycl/blas/src/operations/blas3/gemm_load_store_complex.hpp
+++ b/onemath/sycl/blas/src/operations/blas3/gemm_load_store_complex.hpp
@@ -118,8 +118,7 @@ class vec_complex {
 
   // Load
   template <address_t Space, decorated_t DecorateAddress>
-  void load(size_t Offset,
-            const DataT* Ptr) {
+  void load(size_t Offset, const DataT *Ptr) {
     m_Data = *(Ptr + Offset * NumElements);
   }
 
@@ -132,8 +131,7 @@ class vec_complex {
 
   // Store
   template <address_t Space, decorated_t DecorateAddress>
-  void store(size_t Offset,
-             DataT* Ptr) const {
+  void store(size_t Offset, DataT *Ptr) const {
     *(Ptr + Offset * NumElements) = m_Data;
   }
 };

--- a/onemath/sycl/blas/src/operations/blas3/gemm_local.hpp
+++ b/onemath/sycl/blas/src/operations/blas3/gemm_local.hpp
@@ -527,6 +527,9 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
       element_t *reg, OutputPointerType out_ptr) {
     vector_out_t out_vec{};
 
+    // This if-statement is necessary starting from late 2024 nightly, because
+    // an update made casting raw pointers of sycl::complex to multi_ptr
+    // ambiguous.
     if constexpr (std::is_same_v<
                       element_t,
                       sycl::ext::oneapi::experimental::complex<float>> ||

--- a/onemath/sycl/blas/src/operations/blas3/gemm_local.hpp
+++ b/onemath/sycl/blas/src/operations/blas3/gemm_local.hpp
@@ -537,8 +537,8 @@ class Gemm<input_t, output_t, DoubleBuffer, NbcA, NbcB, ClSize, TileType,
                             sycl::access::decorated::legacy>(0, reg);
       out_vec *= alpha_;
 
-    out_vec.template store<address_t::global_space, sycl::access::decorated::legacy>(
-        0, out_ptr);
+      out_vec.template store<address_t::global_space,
+                             sycl::access::decorated::legacy>(0, out_ptr);
     } else {
       out_vec.template load<address_t::private_space,
                             sycl::access::decorated::legacy>(


### PR DESCRIPTION
This patch update the include path and check for complex header, due to compiler changes of default include path.

After updating the header inclusion, an issue with `sycl::multi_ptr` cast of `sycl::complex` type arose.
This patch work-around the issue by overloading the load/store function of the internal vector representation for complex type.

Attaching logs using oneMath test both using a recent nightly and latest  icpx version (oneAPI 2025):
-  [icpx_fix_complex.txt](https://github.com/user-attachments/files/18379073/icpx_fix_complex.txt)
-  [clang_fix_complex.txt](https://github.com/user-attachments/files/18379074/clang_fix_complex.txt)
