### PR TITLE
Fix BLAS compilation with AdaptiveCpp and export CMake options

### DIFF
--- a/onemath/sycl/blas/CMakeLists.txt
+++ b/onemath/sycl/blas/CMakeLists.txt
@@ -65,10 +65,9 @@ option(BLAS_ENABLE_EXTENSIONS "Whether to enable BLAS extensions" ON)
 option(BLAS_ENABLE_COMPLEX "Whether to enable complex data type for GEMM" ON)
 option(BLAS_ENABLE_HALF "Whether to enable sycl::half data type for supported operators" ON)
 
-if (SYCL_COMPILER MATCHES "adaptivecpp") 
+if (SYCL_COMPILER MATCHES "adaptivecpp" OR ${CMAKE_CXX_COMPILER} MATCHES "acpp|syclcc")
   if(BLAS_ENABLE_COMPLEX)
-    message(STATUS "SYCL Complex data is not supported on AdaptiveCpp/hipSYCL. Complex
-            data type is disabled")
+    message(STATUS "SYCL Complex data is not supported on AdaptiveCpp/hipSYCL. Complex data type is disabled")
     set(BLAS_ENABLE_COMPLEX OFF)
   endif()
 endif()

--- a/onemath/sycl/blas/CMakeLists.txt
+++ b/onemath/sycl/blas/CMakeLists.txt
@@ -63,12 +63,17 @@ set(ONEMATH_SYCL_BLAS_INSTALL_SRC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/
 
 option(BLAS_ENABLE_EXTENSIONS "Whether to enable BLAS extensions" ON)
 option(BLAS_ENABLE_COMPLEX "Whether to enable complex data type for GEMM" ON)
+option(BLAS_ENABLE_USM "Whether to enable USM API" ON)
 option(BLAS_ENABLE_HALF "Whether to enable sycl::half data type for supported operators" ON)
 
 if (SYCL_COMPILER MATCHES "adaptivecpp" OR ${CMAKE_CXX_COMPILER} MATCHES "acpp|syclcc")
   if(BLAS_ENABLE_COMPLEX)
     message(STATUS "SYCL Complex data is not supported on AdaptiveCpp/hipSYCL. Complex data type is disabled")
     set(BLAS_ENABLE_COMPLEX OFF)
+  endif()
+  if (BLAS_ENABLE_USM)
+    message(STATUS "USM API is not supported on AdaptiveCpp/hipSYCL. USM API is disabled")
+    set(BLAS_ENABLE_USM OFF)
   endif()
 endif()
 
@@ -78,7 +83,6 @@ set_target_properties(onemath_sycl_blas PROPERTIES
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-fsycl" is_dpcpp)
 if(is_dpcpp)
-  target_compile_definitions(onemath_sycl_blas INTERFACE "SB_ENABLE_USM")
   check_cxx_compiler_flag("-mllvm=-enable-global-offset=false" support_disable_global_offset)
   if (${support_disable_global_offset})
     if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
@@ -94,6 +98,9 @@ endif()
 if(${BLAS_ENABLE_COMPLEX})
   target_compile_definitions(onemath_sycl_blas INTERFACE "BLAS_ENABLE_COMPLEX")
 endif()
+if(${BLAS_ENABLE_USM})
+  target_compile_definitions(onemath_sycl_blas INTERFACE "SB_ENABLE_USM")
+endif()
 target_compile_definitions(onemath_sycl_blas INTERFACE ${TUNING_TARGET})
 target_compile_options(onemath_sycl_blas INTERFACE -Wno-deprecated-declarations)
 target_compile_options(onemath_sycl_blas INTERFACE -Wno-deprecated-copy-with-user-provided-copy)
@@ -107,14 +114,23 @@ endif()
 
 include(CMakePackageConfigHelpers)
 set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/onemath_sycl_blas-version.cmake")
+set(config_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/onemath_sycl_blas-config.cmake")
+set(targets_name "onemath_sycl_blas-targets")
 write_basic_package_version_file(${version_file}
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
+configure_package_config_file(
+  cmake/config.cmake.in
+  ${config_file}
+  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}
+)
+install(FILES ${version_file} ${config_file}
+  DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 include(GNUInstallDirs)
 install(TARGETS onemath_sycl_blas
-  EXPORT onemath_sycl_blas
+  EXPORT ${targets_name}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -131,16 +147,9 @@ install(DIRECTORY ${ONEMATH_SYCL_BLAS_INCLUDE}
     FILES_MATCHING PATTERN "*.hpp"
   )
 
-install(FILES ${version_file} DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(EXPORT onemath_sycl_blas
+install(EXPORT ${targets_name}
   DESTINATION ${CMAKE_INSTALL_PREFIX}
   NAMESPACE ONEMATH_SYCL_BLAS::
-  FILE onemath_sycl_blas-config.cmake
-)
-
-export(EXPORT onemath_sycl_blas
-  NAMESPACE ONEMATH_SYCL_BLAS::
-  FILE onemath_sycl_blas-config.cmake
 )
 
 option(BLAS_ENABLE_CONST_INPUT "Whether to enable kernel instantiation with const input buffer" ON)

--- a/onemath/sycl/blas/CMakeLists.txt
+++ b/onemath/sycl/blas/CMakeLists.txt
@@ -113,7 +113,7 @@ if((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM") AND NOT
 endif()
 
 include(CMakePackageConfigHelpers)
-set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/onemath_sycl_blas-version.cmake")
+set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/onemath_sycl_blas-config-version.cmake")
 set(config_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/onemath_sycl_blas-config.cmake")
 set(targets_name "onemath_sycl_blas-targets")
 write_basic_package_version_file(${version_file}

--- a/onemath/sycl/blas/CMakeLists.txt
+++ b/onemath/sycl/blas/CMakeLists.txt
@@ -21,7 +21,7 @@
 # *
 # **************************************************************************/
 cmake_minimum_required(VERSION 3.4.3)
-project(blas VERSION 0.1.0 LANGUAGES CXX)
+project(blas VERSION 0.2.0 LANGUAGES CXX)
 
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/onemath/sycl/blas/cmake/config.cmake.in
+++ b/onemath/sycl/blas/cmake/config.cmake.in
@@ -1,0 +1,27 @@
+#/***************************************************************************
+# *
+# *  @license
+# *  Copyright (C) Codeplay Software Limited
+# *  Licensed under the Apache License, Version 2.0 (the "License");
+# *  you may not use this file except in compliance with the License.
+# *  You may obtain a copy of the License at
+# *
+# *      http://www.apache.org/licenses/LICENSE-2.0
+# *
+# *  For your convenience, a copy of the License has been included in this
+# *  repository.
+# *
+# *  Unless required by applicable law or agreed to in writing, software
+# *  distributed under the License is distributed on an "AS IS" BASIS,
+# *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# *  See the License for the specific language governing permissions and
+# *  limitations under the License.
+# *
+# *
+# *
+# **************************************************************************/
+@PACKAGE_INIT@
+set(BLAS_ENABLE_COMPLEX "@BLAS_ENABLE_COMPLEX@")
+set(BLAS_ENABLE_USM "@BLAS_ENABLE_USM@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_name@.cmake")

--- a/onemath/sycl/blas/include/helper.h
+++ b/onemath/sycl/blas/include/helper.h
@@ -88,27 +88,6 @@ using add_const = typename std::conditional<
         typename std::remove_pointer<container_t>::type>::type>::type,
     container_t>::type;
 
-template <typename container_t>
-typename std::enable_if<std::is_same<
-    container_t, typename AllocHelper<typename ValueType<container_t>::type,
-                                      AllocType::usm>::type>::value>::type
-enqueue_deallocate(std::vector<sycl::event> dependencies, container_t mem,
-                   sycl::queue q) {
-#ifdef SB_ENABLE_USM
-  auto event = q.submit([&](sycl::handler &cgh) {
-    cgh.depends_on(dependencies);
-    cgh.host_task([=]() { sycl::free(mem, q); });
-  });
-#endif
-  return;
-}
-
-template <typename container_t>
-typename std::enable_if<std::is_same<
-    container_t, typename AllocHelper<typename ValueType<container_t>::type,
-                                      AllocType::buffer>::type>::value>::type
-enqueue_deallocate(std::vector<sycl::event>, container_t mem, sycl::queue q) {}
-
 inline bool has_local_memory(sycl::queue &q) {
   return (
       q.get_device().template get_info<sycl::info::device::local_mem_type>() ==


### PR DESCRIPTION
1. Remove unused function `enqueue_deallocate` in `helper.h` (left over from refactoring).
2. Add missing `BLAS_ENABLE_COMPLEX` protection in `Gemm::store_packet`.
3. Skip second template parameter in `sycl::vec::load` and `sycl::vec::store` calls in `Gemm::store_packet` when compiling with AdaptiveCpp, which [doesn't support it](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/116696862f50bda515b0a1e4357b3bf7d0f6692f/include/hipSYCL/sycl/libkernel/vec.hpp#L542).
4. Improve detection of using AdaptiveCpp in CMake configuration to disable complex data support.
5. Properly define and export cmake options `BLAS_ENABLE_COMPLEX` and `BLAS_ENABLE_USM` such that dependent projects can read and use them.
6. Bump project version to 0.2.0, marking the CMake changes in the previous point.

