### PR TITLE
Fix build for CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13)
 project(generic_sycl_components VERSION 0.1.0 LANGUAGES CXX)
 
 include_directories(onemath/sycl/blas)

--- a/onemath/sycl/blas/CMakeLists.txt
+++ b/onemath/sycl/blas/CMakeLists.txt
@@ -20,7 +20,7 @@
 # *
 # *
 # **************************************************************************/
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.13)
 project(blas VERSION 0.2.0 LANGUAGES CXX)
 
 if(POLICY CMP0074)

--- a/onemath/sycl/blas/README.md
+++ b/onemath/sycl/blas/README.md
@@ -352,7 +352,7 @@ We do not use any OpenCL interoperability, hence, the code is pure C++.
 The project is developed using [DPCPP open source](https://github.com/intel/llvm)
 or [oneapi release](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html#gs.2iaved),
 using Ubuntu 22.04 on Intel OpenCL CPU, Intel GPU, NVIDIA GPU and AMD GPU.
-The build system is CMake version 3.4.3 or higher.
+The build system is CMake version 3.13 or higher.
 
 ## Setup
 


### PR DESCRIPTION
CMake 3.31 and 4.0 no longer support anything older than 3.5 and also generate warning that everything older than 3.10 will be removed in upcoming cmake version.
This PR updates cmake_minimum_required in case of the latest cmake is used.